### PR TITLE
Drop extra `postfix_sasl_users` from sasl config.

### DIFF
--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -26,10 +26,10 @@
 
 - type: replace
   path: /variables/name=postfix_ssl/options/alternative_names
-  value: [ ((terraform_outputs.production_smtp_private_ip)), "smtp.fr.cloud.gov" ]
+  value:
+  - ((terraform_outputs.production_smtp_private_ip))
+  - smtp.fr.cloud.gov  # This name doesn't exist but might one day; ask @timothy-spencer
 
 - type: replace
-  path: /instance_groups/name=postfix/jobs/release=postfix/properties/postfix/sasl_users
-  value:
-    postfix_sasl_users:
-      cloudgov: ((cloudgov_pw))
+  path: /instance_groups/name=postfix/jobs/release=postfix/properties/postfix/sasl_users/cloudgov?
+  value: ((cloudgov_pw))


### PR DESCRIPTION
Current config looks like

```
echo "{"cloudgov"=>"<redacted>"}" | saslpasswd2 -c -u $(postconf -h mydomain) "postfix_sasl_users"
```

Should be

```
echo "<redacted>" | saslpasswd2 -c -u $(postconf -h mydomain) "cloudgov"
```