### PR TITLE
smtp.fr.cloud.gov does not exist and is not planned

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -52,6 +52,6 @@ variables:
   options:
     ca: postfix_ca
     common_name: 10.244.8.64
-    alternative_names: [ 10.244.8.64, "smtp.fr.cloud.gov" ]
+    alternative_names: [ 10.244.8.64 ]
 - name: cloudgov_pw
   type: password

--- a/bosh/opsfiles/production.yml
+++ b/bosh/opsfiles/production.yml
@@ -28,7 +28,6 @@
   path: /variables/name=postfix_ssl/options/alternative_names
   value:
   - ((terraform_outputs.production_smtp_private_ip))
-  - smtp.fr.cloud.gov  # This name doesn't exist but might one day; ask @timothy-spencer
 
 - type: replace
   path: /instance_groups/name=postfix/jobs/release=postfix/properties/postfix/sasl_users?/cloudgov

--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -1,7 +1,7 @@
 postfix_root_recipient: /dev/null
 postfix_mynetworks:
   - 10.0.0.0/8
-postfix_myhostname: smtp.fr.cloud.gov
+postfix_myhostname: smtp.fr.cloud.gov.localhost
 postfix_use_tls: true
 postfix_dkim_maildomain: cloud.gov
 postfix_use_sasl: true


### PR DESCRIPTION
Switch to .localhost domain per rfc2606. There are no plans for smtp.fr.cloud.gov to exist