### PR TITLE
Restore hostname.

### DIFF
--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -1,10 +1,9 @@
 postfix_root_recipient: /dev/null
 postfix_mynetworks:
-  - 10.0.0.0/8
-postfix_myhostname: smtp.fr.cloud.gov.localhost
+- 10.0.0.0/8
+postfix_myhostname: smtp.fr.cloud.gov
 postfix_use_tls: true
 postfix_dkim_maildomain: cloud.gov
 postfix_use_sasl: true
-# This is a list of users who can auth to the smtp server with users as keys and passwords as values
 postfix_sasl_users: 
   cloudgov: ((cloudgov_pw))


### PR DESCRIPTION
When we changed the hostname to clarify that smtp.fr.cloud.gov isn't
resolvable via dns, we also broke authentication for clients using that
hostname. This patch reverts that change.