### PR TITLE
Run jobs in serial.

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -13,7 +13,7 @@ update:
 
 stemcells:
 - alias: default
-  name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+  os: ubuntu-trusty
   version: latest
 
 instance_groups:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -70,6 +70,7 @@ resources:
 
 jobs:
 - name: plan-postfix-production
+  serial_groups: [deploy]
   plan:
   - aggregate:
     - get: stemcell
@@ -115,6 +116,7 @@ jobs:
       icon_url: ((slack-icon-url))
 
 - name: deploy-postfix-production
+  serial_groups: [deploy]
   plan:
   - aggregate:
     - get: postfix-config
@@ -160,6 +162,7 @@ jobs:
       icon_url: ((slack-icon-url))
 
 - name: smoke-tests-production
+  serial_groups: [deploy]
   plan:
   - aggregate:
     - get: postfix-config


### PR DESCRIPTION
Avoid bosh lock errors and false positive test failures from running
jobs at the same time.