### PR TITLE
Update stemcell to xenial

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -30,10 +30,10 @@ resources:
     regexp: postfix-(.*).tgz
     region_name: ((aws-region))
 
-- name: stemcell
+- name: stemcell-xenial
   type: bosh-io-stemcell
   source:
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
 
 - name: terraform-yaml
   type: s3-iam
@@ -73,7 +73,7 @@ jobs:
   serial_groups: [deploy]
   plan:
   - aggregate:
-    - get: stemcell
+    - get: stemcell-xenial
       trigger: true
     - get: postfix-config
       trigger: true
@@ -87,7 +87,7 @@ jobs:
       manifest: postfix-config/bosh/manifest.yml
       dry_run: true
       stemcells:
-      - stemcell/*.tgz
+      - stemcell-xenial/*.tgz
       releases:
       - postfix-release/*.tgz
       ops_files:
@@ -123,7 +123,7 @@ jobs:
       passed: [plan-postfix-production]
     - get: postfix-release
       passed: [plan-postfix-production]
-    - get: stemcell
+    - get: stemcell-xenial
       passed: [plan-postfix-production]
     - get: terraform-yaml
       passed: [plan-postfix-production]
@@ -133,7 +133,7 @@ jobs:
     params:
       manifest: postfix-config/bosh/manifest.yml
       stemcells:
-      - stemcell/*.tgz
+      - stemcell-xenial/*.tgz
       releases:
       - postfix-release/*.tgz
       ops_files:


### PR DESCRIPTION
Updates stemcell to xenial and renames stemcell resource so Concourse does not get confused by xenial's lower version numbers